### PR TITLE
 カレンダー内から直接家計簿登録したい #50

### DIFF
--- a/src/components/FooterMenu.tsx
+++ b/src/components/FooterMenu.tsx
@@ -1,5 +1,5 @@
 import { BottomNavigation, BottomNavigationAction, Box } from "@mui/material";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import EditIcon from "@mui/icons-material/Edit";
 import EqualizerIcon from "@mui/icons-material/Equalizer";
@@ -14,6 +14,11 @@ export const FooterMenu = () => {
     setValue(newValue);
     navigate(newValue);
   };
+
+  useEffect(() => {
+    setValue(location.pathname);
+  }, [location.pathname]);
+
   return (
     <Box sx={{ width: "100%", position: "fixed", bottom: "0" }}>
       <BottomNavigation showLabels value={value} onChange={handleChange}>

--- a/src/pages/Event/Calendar.module.css
+++ b/src/pages/Event/Calendar.module.css
@@ -22,6 +22,23 @@
   background-color: white;
 }
 
+.clickedDate {
+  list-style-type: none;
+  border-bottom: 2px solid #ebebeb;
+  padding: 15px 0;
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 33px;
+  background-color: azure;
+}
+
+.clickedDateItem {
+  margin: auto 0;
+  font-size: 1.2em;
+  font-weight: bold;
+  height: 100%;
+}
+
 .eventContents {
   list-style-type: none;
   border-bottom: 2px solid #ebebeb;

--- a/src/pages/Event/Calendar.tsx
+++ b/src/pages/Event/Calendar.tsx
@@ -4,7 +4,7 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import jaLocale from "@fullcalendar/core/locales/ja";
 import styles from "./Calendar.module.css";
 import "./calendar.css";
-import { Box, Button, CircularProgress, FormControl, IconButton, MenuItem, Select } from "@mui/material";
+import { Box, CircularProgress, FormControl, IconButton, MenuItem, Select } from "@mui/material";
 import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
 import { EventClickArg } from "@fullcalendar/core";
 import { format } from "date-fns";
@@ -22,7 +22,7 @@ export const Calendar = memo(() => {
   const navigate = useNavigate();
   const events = useRecoilValue(eventSelector).event;
   const eventAmount = useRecoilValue(eventSelector).calendar;
-  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedDate, setSelectedDate] = useState(new Date().toISOString().substr(0, 10));
   const revision = localStorage.getItem("revision");
   const [eventFlag, setEventFlag] = useRecoilState(eventFlagAtom);
   const [loading, setLoading] = useState(true);

--- a/src/pages/Event/Calendar.tsx
+++ b/src/pages/Event/Calendar.tsx
@@ -144,6 +144,7 @@ export const EventList = ({ events, selectedDate }: { events: Event; selectedDat
   const categories = useRecoilValue(categoryAtom);
   return (
     <ul className={styles.eventList}>
+      <li>{selectedDate}</li>
       {selectedDate && events[selectedDate] ? (
         events[selectedDate].map((item, index) => (
           <li key={index} className={styles.eventContents}>

--- a/src/pages/Event/Calendar.tsx
+++ b/src/pages/Event/Calendar.tsx
@@ -143,11 +143,17 @@ export const Calendar = memo(() => {
 
 export const EventList = ({ events, selectedDate }: { events: Event; selectedDate: string }) => {
   const categories = useRecoilValue(categoryAtom);
+  const navigate = useNavigate();
+
+  const toEventRegister = () => {
+    navigate(`/event-register?date=${selectedDate}`);
+  };
+
   return (
     <ul className={styles.eventList}>
       <li className={styles.clickedDate}>
         <p className={styles.clickedDateItem}>{selectedDate}</p>
-        <IconButton className={styles.clickedDateItem}>
+        <IconButton className={styles.clickedDateItem} onClick={toEventRegister}>
           <AddCircleOutlineIcon />
         </IconButton>
       </li>

--- a/src/pages/Event/Calendar.tsx
+++ b/src/pages/Event/Calendar.tsx
@@ -4,7 +4,7 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import jaLocale from "@fullcalendar/core/locales/ja";
 import styles from "./Calendar.module.css";
 import "./calendar.css";
-import { Box, CircularProgress, FormControl, MenuItem, Select } from "@mui/material";
+import { Box, Button, CircularProgress, FormControl, IconButton, MenuItem, Select } from "@mui/material";
 import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
 import { EventClickArg } from "@fullcalendar/core";
 import { format } from "date-fns";
@@ -16,6 +16,7 @@ import { Event } from "../../types";
 import { eventApi } from "../../api/eventApi";
 import { db } from "../../db/db";
 import { categoryAtom } from "../../recoil/CategoryAtom";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 
 export const Calendar = memo(() => {
   const navigate = useNavigate();
@@ -144,7 +145,12 @@ export const EventList = ({ events, selectedDate }: { events: Event; selectedDat
   const categories = useRecoilValue(categoryAtom);
   return (
     <ul className={styles.eventList}>
-      <li>{selectedDate}</li>
+      <li className={styles.clickedDate}>
+        <p className={styles.clickedDateItem}>{selectedDate}</p>
+        <IconButton className={styles.clickedDateItem}>
+          <AddCircleOutlineIcon />
+        </IconButton>
+      </li>
       {selectedDate && events[selectedDate] ? (
         events[selectedDate].map((item, index) => (
           <li key={index} className={styles.eventContents}>

--- a/src/pages/Event/EventRegister.tsx
+++ b/src/pages/Event/EventRegister.tsx
@@ -4,7 +4,7 @@ import styles from "./Event.module.css";
 import { Box, Button, FormControl, IconButton, InputLabel, MenuItem, Select, TextField, ThemeProvider } from "@mui/material";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { eventApi } from "../../api/eventApi";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { EventRegisterForm, Pattern } from "../../types";
 import { db } from "../../db/db";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -19,6 +19,8 @@ import { categoryAtom } from "../../recoil/CategoryAtom";
 
 export const EventRegister = () => {
   const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const selectedDate = params.get("date") ?? new Date().toISOString().substr(0, 10);
   const [hasPattern, setHasPattern] = useState(false);
   const [loading, setLoading] = useState(false);
   const [display, setDisplay] = useState(false);
@@ -320,7 +322,7 @@ export const EventRegister = () => {
               id="date"
               label="日付"
               type="date"
-              defaultValue={new Date().toISOString().substr(0, 10)}
+              defaultValue={selectedDate}
               InputLabelProps={{
                 shrink: true,
               }}


### PR DESCRIPTION
- カレンダー内でクリックした日付を表示させる
- カレンダーを表示させたとき、今日の日付が選択された状態にする
- 表示させた日付部分からイベントの新規登録機能を実装
- カレンダーから新規登録する場合は、その日付を初期値とする

issue:  カレンダー内から直接家計簿登録したい #50 