### PR TITLE
設定画面表示時にRecoilのSelectorで内で親かチェックを行う #58

### DIFF
--- a/src/pages/Setting/Setting.tsx
+++ b/src/pages/Setting/Setting.tsx
@@ -1,40 +1,27 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import styles from "./Setting.module.css";
 import { Box, Button } from "@mui/material";
-import CircularProgress from "@mui/material/CircularProgress";
 import { useNavigate } from "react-router-dom";
 import { authApi } from "../../api/authApi";
-import { settingApi } from "../../api/settingApi";
 import { db } from "../../db/db";
+import { useRecoilValue } from "recoil";
+import { parentFlagSelector } from "../../recoil/ParentFlagAtom";
 
 export const Setting = () => {
   const navigate = useNavigate();
-  const [isParent, setIsParent] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const isParent = useRecoilValue(parentFlagSelector);
 
   useEffect(() => {
     // グループの親かどうかチェック
     const checkParent = async () => {
-      try {
-        const res = await settingApi.isParent();
-        if (res.status === 200) {
-          setIsParent(res.data.parent);
-        } else if (res.status === 401) {
-          alert("ログインしてください");
-          navigate("/login");
-        } else {
-          alert("エラーが発生しました");
-          console.log(res);
-        }
-      } catch (err) {
-        alert("エラーが発生しました");
-        console.log(err);
-      } finally {
-        setLoading(false);
+      if (isParent === 401) {
+        alert("ログインしてください");
+        navigate("/login");
       }
     };
     checkParent();
-  }, [navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const clickLogout = async () => {
     const res = window.confirm("ログアウトしてもよろしいですか？");
@@ -59,18 +46,8 @@ export const Setting = () => {
   };
   return (
     <div className={styles.container}>
-      {loading ? (
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-            // marginTop: "330px",
-            alignItems: "center",
-            height: "100%",
-          }}
-        >
-          <CircularProgress />
-        </Box>
+      {isParent === -1 ? (
+        <div>エラーが発生しました</div>
       ) : (
         <div>
           <h2>設定</h2>

--- a/src/recoil/ParentFlagAtom.ts
+++ b/src/recoil/ParentFlagAtom.ts
@@ -1,0 +1,38 @@
+import { DefaultValue, atom, selector } from "recoil";
+import { settingApi } from "../api/settingApi";
+
+export const parentFlagAtom = atom({
+  key: "ParentFlagAtom",
+  default: -1,
+});
+
+// indexedDBの値を変換
+export const parentFlagSelector = selector({
+  key: "ParentFlagSelector",
+  get: async ({ get }) => {
+    const flag = get(parentFlagAtom);
+    if (flag === -1) {
+      try {
+        const res = await settingApi.isParent();
+        if (res.status === 200) {
+          if (res.data.parent) {
+            return 1;
+          } else {
+            return 0;
+          }
+        } else if (res.status === 401) {
+          return 401;
+        } else {
+          console.log(res);
+          return -1;
+        }
+      } catch (err) {
+        console.log(err);
+        return -1;
+      }
+    } else {
+      return flag;
+    }
+  },
+  set: ({ set }, newValue: number | undefined | DefaultValue) => set(parentFlagAtom, newValue!),
+});


### PR DESCRIPTION
設定画面表示時に、自分が親かどうか毎回チェックしていた。
RecoilのAtomで自分が親かどうかの情報を保持してくように変更。
一度も情報取得を行っていない場合はSelector内で取得を行う。
また、それに伴いコンポーネントからローディング表示をなくして、Selectorで取得エラーが発生した場合はエラーページを表示するように修正。

issue:  処理が重い原因の調査 #58 