### PR TITLE
ログイン情報をAtomで管理するように修正 #58

### DIFF
--- a/src/components/layout/MenuLayout.tsx
+++ b/src/components/layout/MenuLayout.tsx
@@ -1,44 +1,35 @@
-import { Box, CircularProgress } from "@mui/material";
+import { Box } from "@mui/material";
 import { Outlet, useNavigate } from "react-router-dom";
 import { FooterMenu } from "../FooterMenu";
 import { useEffect, useState } from "react";
-import { authApi } from "../../api/authApi";
+import { useRecoilValue } from "recoil";
+import { loginAtom } from "../../recoil/LoginAtom";
 
 export const MenuLayout = () => {
   const navigate = useNavigate();
-  const [loading, setLoading] = useState(true);
+  const isLogin = useRecoilValue(loginAtom);
+  const [err, setErr] = useState(false);
 
   useEffect(() => {
-    const loginCheck = async () => {
+    const loginCheck = () => {
       try {
         if (localStorage.getItem("token")) {
-          const res = await authApi.isLogin();
-          if (res.status === 401) {
-            alert("ログインしてください");
+          if (isLogin === 0) {
             navigate("/login");
-          } else if (res.status === 200) {
-            // 何もしない
-          } else {
-            alert("エラーが発生しました");
-            console.log(res);
           }
         } else {
-          alert("ログインしてください");
           navigate("/login");
         }
-      } catch (err) {
-        alert("エラーが発生しました");
-        console.log(err);
-      } finally {
-        setLoading(false);
+      } catch (error) {
+        setErr(true);
       }
     };
     loginCheck();
-  }, [navigate]);
+  }, [navigate, isLogin]);
   return (
     <Box sx={{ display: "flex", flexDirection: "column", width: "100%" }}>
       <Box sx={{ flexGrow: 1, width: "100%" }}>
-        {loading ? (
+        {err ? (
           <Box
             sx={{
               display: "flex",
@@ -48,7 +39,7 @@ export const MenuLayout = () => {
               height: "100%",
             }}
           >
-            <CircularProgress />
+            エラーが発生しました
           </Box>
         ) : (
           <Outlet />

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -14,6 +14,8 @@ import { GoogleLogin } from "react-google-login";
 import { eventApi } from "../../api/eventApi";
 import { db } from "../../db/db";
 import { privateApi } from "../../api/privateApi";
+import { useSetRecoilState } from "recoil";
+import { loginAtom } from "../../recoil/LoginAtom";
 
 export const Login = () => {
   const navigate = useNavigate();
@@ -21,6 +23,7 @@ export const Login = () => {
   const [buttonLoading, setButtonLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   const clientId = process.env.REACT_APP_CLIENT_ID;
+  const setIsLogin = useSetRecoilState(loginAtom);
 
   // react-hook-formの設定
   const {
@@ -36,6 +39,7 @@ export const Login = () => {
         if (localStorage.getItem("token")) {
           const res = await authApi.isLogin();
           if (res.status === 200) {
+            setIsLogin(1);
             navigate("/event-register");
           }
         }
@@ -46,7 +50,8 @@ export const Login = () => {
       }
     };
     loginCheck();
-  }, [navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Googleログイン用の設定
   useEffect(() => {
@@ -82,6 +87,7 @@ export const Login = () => {
             }).then(() => {
               // リビジョンを保存
               localStorage.setItem("revision", revision.data.revision);
+              setIsLogin(1);
               setTimeout(() => {
                 navigate("/event-register");
               }, 1000);
@@ -127,6 +133,7 @@ export const Login = () => {
             }).then(() => {
               // リビジョンを保存
               localStorage.setItem("revision", revision.data.revision);
+              setIsLogin(1);
               setTimeout(() => {
                 navigate("/event-register");
               }, 1000);

--- a/src/recoil/LoginAtom.ts
+++ b/src/recoil/LoginAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const loginAtom = atom({
+  key: "LoginAtom",
+  default: 0,
+});


### PR DESCRIPTION
メニューをクリックするたびAPIを叩いてログインチェックを行っていたため、処理が重い。
ログイン状態をAtomで管理して、APIを叩くのではなくAtomを使ってログインチェックを行うように修正。

issue: 処理が重い原因の調査 #58